### PR TITLE
chore: make Renovate config explicit

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,22 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>renovatebot/.github"]
+  "extends": ["config:base", "helpers:pinGitHubActionDigests"],
+  "prCreation": "not-pending",
+  "internalChecksFilter": "strict",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true
+  },
+  "packageRules": [
+    {
+      "description": "Wait 3 days before creating a npm update PR",
+      "matchDatasources": ["npm"],
+      "stabilityDays": 3
+    },
+    {
+      "description": "Automerge Prettier updates",
+      "matchDepTypes": ["devDependencies"],
+      "matchPackagePatterns": ["prettier"],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
## Changes

- Make the Renovate config explicit

## Context

Extending from `renovatebot/.github` doesn't work properly for us right now. It will probably work okay once this repository is moved to the `renovatebot` organization.

For now, I'll use a basic configuration to at get updates going.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/HonkingGoose/vale-plain-language-guidelines/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
